### PR TITLE
README.md: improve error handling in the sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,14 @@ var bitcoin_rpc = require('node-bitcoin-rpc')
 
 bitcoin_rpc.init('host', port, 'rpc_username', rpc_pass)
 bitcoin_rpc.call('getbalance', [], function (err, res) {
-  if (err !== null) {
-    console.log('I have an error :( ' + err + ' ' + res.error)
+  if (err) {
+    let errMsg = "Error when calling bitcoin RPC: " + err;
+    console.log(errMsg);
+    throw new Error(errMsg);
+  } else if (res.error) {
+    let errMsg = "Error received by bitcoin RPC: " + res.error.message + " (" + res.error.code + ")";
+    console.log(errMsg);
+    throw new Error(errMsg);
   } else {
     console.log('Yay! I need to do whatever now with ' + res.result)
   }


### PR DESCRIPTION
When bitcoin RPC throws an error, it fills the result like this:

```
{ result: null,
  error: 
   { code: -12,
     message: 'Error: Keypool ran out, please call keypoolrefill first' },
  id: '1' }
```

Therefore, if result.error is not null, let's print result.error.message and result.error.code, otherwise we don't get any useful info in the log.